### PR TITLE
feat: add ApiOnly decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ export default class CustomersController {
 }
 ```
 
+You can also create a resource that is API only.
+
+```typescript
+// CustomersController.ts
+import { ApiOnly, Resource } from "@ioc:SoftwareCitadel/Girouette"
+
+@Resource("/users", "users")
+@ApiOnly()
+export default class CustomersController {
+  // ...
+}
+```
 
 
 [npm-image]: https://img.shields.io/npm/v/@softwarecitadel/adonisjs-girouette.svg?style=for-the-badge&logo=npm

--- a/adonis-typings/girouette.ts
+++ b/adonis-typings/girouette.ts
@@ -22,5 +22,7 @@ declare module '@ioc:SoftwareCitadel/Girouette' {
 
   const Resource: (pattern: string, name?: string) => (target: any) => void
 
-  export { Delete, Get, Patch, Post, Put, Middleware, Resource, Where }
+  const ApiOnly: () => (target: any) => void
+
+  export { Delete, Get, Patch, Post, Put, Middleware, Resource, ApiOnly, Where }
 }

--- a/providers/GirouetteProvider.ts
+++ b/providers/GirouetteProvider.ts
@@ -12,6 +12,7 @@ export default class GirouetteProvider {
       const { Get, Post, Put, Patch, Delete } = require('../src/Decorators/RouteDecorators')
       const { Where } = require('../src/Decorators/Where')
       const { Resource } = require('../src/Decorators/Resource')
+      const { ApiOnly } = require('../src/Decorators/ApiOnly')
 
       return {
         Middleware,
@@ -22,6 +23,7 @@ export default class GirouetteProvider {
         Delete,
         Where,
         Resource,
+        ApiOnly,
       }
     })
   }
@@ -42,6 +44,10 @@ export default class GirouetteProvider {
         const resourceName = Reflect.getMetadata('__resource_name__', controller)
         if (resourceName) {
           resource.as(resourceName)
+        }
+        const apiOnly = Reflect.getMetadata('__resource_api_only__', controller)
+        if (apiOnly) {
+          resource.apiOnly()
         }
       }
 

--- a/src/Decorators/ApiOnly.ts
+++ b/src/Decorators/ApiOnly.ts
@@ -1,0 +1,5 @@
+export const ApiOnly = () => {
+  return (target: any) => {
+    Reflect.defineMetadata('__resource_api_only__', true, target)
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "./node_modules/@adonisjs/mrm-preset/_tsconfig",
   "compilerOptions": {
-    "types": [
-      "@adonisjs/core"
-    ]
+    "types": ["@adonisjs/core"]
   }
 }


### PR DESCRIPTION
## Proposed changes

This add a new decorator called `ApiOnly`, usable with the `Resource` decorator.
This will call the `.apiOnly()` method if the decorator is added with the `Resource` decorator.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/softwarecitadel/adonisjs-decoratorus/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

While no tests were implemented (Considering this project has none), tests were made and work as expected.