### PR TITLE
fix: Accept string array in Middleware decorator

### DIFF
--- a/adonis-typings/girouette.ts
+++ b/adonis-typings/girouette.ts
@@ -16,7 +16,7 @@ declare module '@ioc:SoftwareCitadel/Girouette' {
   const Put: RouteDecorator
 
   const Middleware: (
-    middleware: string
+    middleware: string | Array<string>
   ) => (target: any, propertyKey: string, descriptor: PropertyDescriptor) => void
 
   const Where: (


### PR DESCRIPTION
## Proposed changes

In `/src/decorators/Middleware` it accepts an array of strings, however when I tried to use an array instead of a string I got an error saying the Middleware only accepts string.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/softwarecitadel/adonisjs-decoratorus/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
