### PR TITLE
Resource actions pick decorators

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,4 +15,6 @@ export { ResourceMiddleware } from './src/decorators/resource_middleware.js'
 export { GroupMiddleware } from './src/decorators/group_middleware.js'
 export * from './src/decorators/resource.js'
 export * from './src/decorators/where.js'
+export * from './src/decorators/only.js'
+
 export { Group, GroupDomain } from './src/decorators/group.js'

--- a/index.ts
+++ b/index.ts
@@ -17,5 +17,6 @@ export * from './src/decorators/resource.js'
 export * from './src/decorators/where.js'
 export * from './src/decorators/only.js'
 export * from './src/decorators/except.js'
+export * from './src/decorators/api_only.js'
 
 export { Group, GroupDomain } from './src/decorators/group.js'

--- a/index.ts
+++ b/index.ts
@@ -16,5 +16,6 @@ export { GroupMiddleware } from './src/decorators/group_middleware.js'
 export * from './src/decorators/resource.js'
 export * from './src/decorators/where.js'
 export * from './src/decorators/only.js'
+export * from './src/decorators/except.js'
 
 export { Group, GroupDomain } from './src/decorators/group.js'

--- a/providers/girouette_provider.ts
+++ b/providers/girouette_provider.ts
@@ -18,7 +18,9 @@ import {
   REFLECT_GROUP_KEY,
   REFLECT_GROUP_MIDDLEWARE_KEY,
   REFLECT_GROUP_DOMAIN_KEY,
+  REFLECT_RESOURCE_ONLY_KEY,
 } from '../src/constants.js'
+import { RouteResource } from '@adonisjs/core/http'
 
 /**
  * Represents a route configuration within the Girouette system
@@ -282,7 +284,7 @@ export default class GirouetteProvider {
   /**
    * Configures a resource with its name and middleware
    */
-  #configureResource(resource: any, controller: any) {
+  #configureResource(resource: RouteResource, controller: any) {
     try {
       const resourceName = Reflect.getMetadata(REFLECT_RESOURCE_NAME_KEY, controller.default)
       if (resourceName) {
@@ -295,6 +297,11 @@ export default class GirouetteProvider {
       )
       if (resourceMiddleware) {
         this.#applyResourceMiddleware(resource, resourceMiddleware)
+      }
+
+      const only = Reflect.getMetadata(REFLECT_RESOURCE_ONLY_KEY, controller.default)
+      if (only) {
+        resource.only(only)
       }
     } catch (error) {
       this.#logger?.debug({ error }, '[Girouette] Error configuring resource')

--- a/providers/girouette_provider.ts
+++ b/providers/girouette_provider.ts
@@ -19,6 +19,7 @@ import {
   REFLECT_GROUP_MIDDLEWARE_KEY,
   REFLECT_GROUP_DOMAIN_KEY,
   REFLECT_RESOURCE_ONLY_KEY,
+  REFLECT_RESOURCE_EXCEPT_KEY,
 } from '../src/constants.js'
 import { RouteResource } from '@adonisjs/core/http'
 
@@ -302,6 +303,11 @@ export default class GirouetteProvider {
       const only = Reflect.getMetadata(REFLECT_RESOURCE_ONLY_KEY, controller.default)
       if (only) {
         resource.only(only)
+      }
+
+      const except = Reflect.getMetadata(REFLECT_RESOURCE_EXCEPT_KEY, controller.default)
+      if (except) {
+        resource.except(except)
       }
     } catch (error) {
       this.#logger?.debug({ error }, '[Girouette] Error configuring resource')

--- a/providers/girouette_provider.ts
+++ b/providers/girouette_provider.ts
@@ -20,6 +20,7 @@ import {
   REFLECT_GROUP_DOMAIN_KEY,
   REFLECT_RESOURCE_ONLY_KEY,
   REFLECT_RESOURCE_EXCEPT_KEY,
+  REFLECT_RESOURCE_API_ONLY_KEY,
 } from '../src/constants.js'
 import { RouteResource } from '@adonisjs/core/http'
 
@@ -300,15 +301,7 @@ export default class GirouetteProvider {
         this.#applyResourceMiddleware(resource, resourceMiddleware)
       }
 
-      const only = Reflect.getMetadata(REFLECT_RESOURCE_ONLY_KEY, controller.default)
-      if (only) {
-        resource.only(only)
-      }
-
-      const except = Reflect.getMetadata(REFLECT_RESOURCE_EXCEPT_KEY, controller.default)
-      if (except) {
-        resource.except(except)
-      }
+      this.#defineResourceActions(resource, controller)
     } catch (error) {
       this.#logger?.debug({ error }, '[Girouette] Error configuring resource')
     }
@@ -320,6 +313,23 @@ export default class GirouetteProvider {
   #applyResourceMiddleware(resource: any, middlewareConfig: any[]) {
     for (const { actions, middleware } of middlewareConfig) {
       resource.middleware(actions, middleware)
+    }
+  }
+
+  #defineResourceActions(resource: any, controller: any) {
+    const apiOnly = Reflect.getMetadata(REFLECT_RESOURCE_API_ONLY_KEY, controller.default)
+    if (apiOnly) {
+      resource.apiOnly()
+    }
+
+    const only = Reflect.getMetadata(REFLECT_RESOURCE_ONLY_KEY, controller.default)
+    if (only) {
+      resource.only(only)
+    }
+
+    const except = Reflect.getMetadata(REFLECT_RESOURCE_EXCEPT_KEY, controller.default)
+    if (except) {
+      resource.except(except)
     }
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const REFLECT_RESOURCE_NAME_KEY = '__girouette_resource_name__'
 
 export const REFLECT_RESOURCE_MIDDLEWARE_KEY = '__girouette_resource_middleware__'
 
+export const REFLECT_RESOURCE_API_ONLY_KEY = '__girouette_resource_api_only__'
 export const REFLECT_RESOURCE_ONLY_KEY = '__girouette_resource_only__'
 export const REFLECT_RESOURCE_EXCEPT_KEY = '__girouette_resource_except__'
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const REFLECT_RESOURCE_NAME_KEY = '__girouette_resource_name__'
 export const REFLECT_RESOURCE_MIDDLEWARE_KEY = '__girouette_resource_middleware__'
 
 export const REFLECT_RESOURCE_ONLY_KEY = '__girouette_resource_only__'
+export const REFLECT_RESOURCE_EXCEPT_KEY = '__girouette_resource_except__'
 
 export const REFLECT_GROUP_KEY = '__girouette_group__'
 export const REFLECT_GROUP_MIDDLEWARE_KEY = '__girouette_group_middleware__'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,8 @@ export const REFLECT_RESOURCE_NAME_KEY = '__girouette_resource_name__'
 
 export const REFLECT_RESOURCE_MIDDLEWARE_KEY = '__girouette_resource_middleware__'
 
+export const REFLECT_RESOURCE_ONLY_KEY = '__girouette_resource_only__'
+
 export const REFLECT_GROUP_KEY = '__girouette_group__'
 export const REFLECT_GROUP_MIDDLEWARE_KEY = '__girouette_group_middleware__'
 export const REFLECT_GROUP_DOMAIN_KEY = '__girouette_group_domain__'

--- a/src/decorators/api_only.ts
+++ b/src/decorators/api_only.ts
@@ -1,0 +1,25 @@
+import { REFLECT_RESOURCE_ONLY_KEY } from '../constants.js'
+
+/**
+ * The `@ApiOnly` decorator removes the routes which aren't needed for an API resource.
+ * (i.e. `create`, `edit`)
+ *
+ * @example
+ * ```ts
+ * @Resource('/posts', 'blog.posts')
+ * @ApiOnly()
+ * export default class PostsController {
+ *   // Generates routes:
+ *   // GET    /posts          (blog.posts.index)
+ *   // POST   /posts          (blog.posts.store)
+ *   // GET    /posts/:id      (blog.posts.show)
+ *   // PUT    /posts/:id      (blog.posts.update)
+ *   // DELETE /posts/:id      (blog.posts.destroy)
+ * }
+ * ```
+ */
+export const ApiOnly = () => {
+  return (target: any) => {
+    Reflect.defineMetadata(REFLECT_RESOURCE_ONLY_KEY, true, target)
+  }
+}

--- a/src/decorators/except.ts
+++ b/src/decorators/except.ts
@@ -1,0 +1,27 @@
+import { REFLECT_RESOURCE_EXCEPT_KEY } from '../constants.js'
+import { ResourceActionNames } from '@adonisjs/core/types/http'
+
+/**
+ * The `@Except` decorator specifies which CRUD methods should be excluded from the resource.
+ *
+ * @param names The CRUD methods to exclude from the resource
+ *
+ * @example
+ * ```ts
+ * @Resource('/posts', 'blog.posts')
+ * @Except(['create', 'show'])
+ * export default class PostsController {
+ *   // Generates routes:
+ *   // GET    /posts          (blog.posts.index)
+ *   // POST   /posts          (blog.posts.store)
+ *   // GET    /posts/:id/edit (blog.posts.edit)
+ *   // PUT    /posts/:id      (blog.posts.update)
+ *   // DELETE /posts/:id      (blog.posts.destroy)
+ * }
+ * ```
+ */
+export const Except = (names: ResourceActionNames[]) => {
+  return (target: any) => {
+    Reflect.defineMetadata(REFLECT_RESOURCE_EXCEPT_KEY, names, target)
+  }
+}

--- a/src/decorators/only.ts
+++ b/src/decorators/only.ts
@@ -1,0 +1,24 @@
+import { REFLECT_RESOURCE_ONLY_KEY } from '../constants.js'
+import { ResourceActionNames } from '@adonisjs/core/types/http'
+
+/**
+ * The `@Only` decorator specifies which CRUD methods should be included in the resource.
+ *
+ * @param names The CRUD methods to include in the resource
+ *
+ * @example
+ * ```ts
+ * @Resource('/posts', 'blog.posts')
+ * @Only(['index', 'show'])
+ * export default class PostsController {
+ *   // Generates routes:
+ *   // GET    /posts          (blog.posts.index)
+ *   // GET    /posts/:id      (blog.posts.show)
+ * }
+ * ```
+ */
+export const Only = (names: ResourceActionNames[]) => {
+  return (target: any) => {
+    Reflect.defineMetadata(REFLECT_RESOURCE_ONLY_KEY, names, target)
+  }
+}

--- a/test/controllers/resource_api_only/posts_controller.ts
+++ b/test/controllers/resource_api_only/posts_controller.ts
@@ -1,0 +1,16 @@
+import { ApiOnly, Resource } from '../../../index.js'
+import { HttpContext } from '@adonisjs/core/http'
+
+@Resource('/posts')
+@ApiOnly()
+export default class PostsController {
+  async store({}: HttpContext) {}
+
+  async index({}: HttpContext) {}
+
+  async show({}: HttpContext) {}
+
+  async update({}: HttpContext) {}
+
+  async destroy({}: HttpContext) {}
+}

--- a/test/controllers/resource_except/posts_controller.ts
+++ b/test/controllers/resource_except/posts_controller.ts
@@ -1,0 +1,10 @@
+import { Except, Resource } from '../../../index.js'
+import { HttpContext } from '@adonisjs/core/http'
+
+@Resource('/posts')
+@Except(['create', 'show'])
+export default class PostsController {
+  async create({}: HttpContext) {}
+
+  async show({}: HttpContext) {}
+}

--- a/test/controllers/resource_only/posts_controller.ts
+++ b/test/controllers/resource_only/posts_controller.ts
@@ -1,0 +1,10 @@
+import { Only, Resource } from '../../../index.js'
+import { HttpContext } from '@adonisjs/core/http'
+
+@Resource('/posts')
+@Only(['update', 'destroy'])
+export default class PostsController {
+  async update({}: HttpContext) {}
+
+  async destroy({}: HttpContext) {}
+}

--- a/test/girouette_provider.spec.ts
+++ b/test/girouette_provider.spec.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { cwd } from 'node:process'
 import { HttpRouterService } from '@adonisjs/core/types'
 import { HTTP_METHODS, RESOURCE_METHODS, ResourceRoute, Route } from './utils.js'
+import { RouteResource } from '@adonisjs/core/http'
 
 test.group('GirouetteProvider', async (group) => {
   let BASE_PATH = join(cwd(), 'test/controllers')
@@ -92,6 +93,23 @@ test.group('GirouetteProvider', async (group) => {
     const controllerMethods: string[] = routes.map((i) => i.handler.reference[1])
 
     assert.isTrue(controllerMethods.every((r) => RESOURCE_METHODS.includes(r)))
+  })
+
+  test('should register specified "only" resource routes', async ({ assert }) => {
+    provider.controllersPath = `${BASE_PATH}/resource_only`
+
+    await provider.start()
+
+    const resource = router.routes[0] as RouteResource
+    const routes = resource.routes
+
+    assert.isFalse(routes.find((route) => route.getName()?.endsWith('.update'))?.isDeleted())
+    assert.isFalse(routes.find((route) => route.getName()?.endsWith('.destroy'))?.isDeleted())
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.index'))?.isDeleted())
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.store'))?.isDeleted())
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.show'))?.isDeleted())
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.edit'))?.isDeleted())
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.create'))?.isDeleted())
   })
 
   test('should register "route_middleware" routes', async ({ assert }) => {

--- a/test/girouette_provider.spec.ts
+++ b/test/girouette_provider.spec.ts
@@ -95,6 +95,18 @@ test.group('GirouetteProvider', async (group) => {
     assert.isTrue(controllerMethods.every((r) => RESOURCE_METHODS.includes(r)))
   })
 
+  test('should not register non "api-only" resource routes ', async ({ assert }) => {
+    provider.controllersPath = `${BASE_PATH}/resource_api_only`
+
+    await provider.start()
+
+    const resource = router.routes[0] as RouteResource
+    const routes = resource.routes
+
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.create'))!.isDeleted())
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.edit'))!.isDeleted())
+  })
+
   test('should register specified "only" resource routes', async ({ assert }) => {
     provider.controllersPath = `${BASE_PATH}/resource_only`
 

--- a/test/girouette_provider.spec.ts
+++ b/test/girouette_provider.spec.ts
@@ -112,6 +112,23 @@ test.group('GirouetteProvider', async (group) => {
     assert.isTrue(routes.find((route) => route.getName()?.endsWith('.create'))?.isDeleted())
   })
 
+  test('should not register "except" resource routes', async ({ assert }) => {
+    provider.controllersPath = `${BASE_PATH}/resource_except`
+
+    await provider.start()
+
+    const resource = router.routes[0] as RouteResource
+    const routes = resource.routes
+
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.create'))?.isDeleted())
+    assert.isTrue(routes.find((route) => route.getName()?.endsWith('.show'))?.isDeleted())
+    assert.isFalse(routes.find((route) => route.getName()?.endsWith('.index'))?.isDeleted())
+    assert.isFalse(routes.find((route) => route.getName()?.endsWith('.store'))?.isDeleted())
+    assert.isFalse(routes.find((route) => route.getName()?.endsWith('.destroy'))?.isDeleted())
+    assert.isFalse(routes.find((route) => route.getName()?.endsWith('.edit'))?.isDeleted())
+    assert.isFalse(routes.find((route) => route.getName()?.endsWith('.update'))?.isDeleted())
+  })
+
   test('should register "route_middleware" routes', async ({ assert }) => {
     provider.controllersPath = `${BASE_PATH}/route_middleware`
 


### PR DESCRIPTION
This PR add three decorators :

- **Only** decorator, to select which routes to keep in a resource controller
- **Except** decorator, to eject routes from a resource controller
- **ApiOnly** decorator, to remove "create" and "edit" actions from a resource controller, which are only needed to generate forms.