### PR TITLE
refactor: use magic string to ensure tuyau compatibility

### DIFF
--- a/test/girouette_provider.spec.ts
+++ b/test/girouette_provider.spec.ts
@@ -72,9 +72,8 @@ test.group('GirouetteProvider', async (group) => {
 
     assert.isTrue(routes.every((r) => r.methods.every((m) => HTTP_METHODS.includes(m))))
 
-    const controllerMethods: string[] = routes.map((i) => i.handler.reference[1])
-
-    assert.isTrue(controllerMethods.every((r) => RESOURCE_METHODS.includes(r)))
+    const controllerMethods: string[] = routes.map((i) => (i.handler.reference as any).split('.').pop() as string)
+    assert.isTrue(controllerMethods.every((r) => RESOURCE_METHODS.includes(r.toLowerCase())))
   })
 
   test('should register "resource_middleware" routes', async ({ assert }) => {
@@ -90,9 +89,8 @@ test.group('GirouetteProvider', async (group) => {
 
     assert.isTrue(routes.every((r) => r.methods.every((m) => HTTP_METHODS.includes(m))))
 
-    const controllerMethods: string[] = routes.map((i) => i.handler.reference[1])
-
-    assert.isTrue(controllerMethods.every((r) => RESOURCE_METHODS.includes(r)))
+    const controllerMethods: string[] = routes.map((i) => (i.handler.reference as any).split('.').pop() as string)
+    assert.isTrue(controllerMethods.every((r) => RESOURCE_METHODS.includes(r.toLowerCase())))
   })
 
   test('should not register non "api-only" resource routes ', async ({ assert }) => {
@@ -164,4 +162,5 @@ test.group('GirouetteProvider', async (group) => {
 
     assert.isTrue(new RegExp(slugMatcher).test('333'))
   })
+
 })


### PR DESCRIPTION
As discussed with @densetsuuu on Discord, this PR will allows Tuyau to be used with Girouette

We use relative magic strings to register routes, which then allows Tuyau to re-import the controller to extract rquest/response types

Example of an output from `node ace list:routes --json` after this PR. The important data is `moduleNameOrPath`. We now have a relative path from the app root to the controller. 

```json
[
  {
    "domain": "root",
    "routes": [
      {
        "name": "posts.index",
        "pattern": "/posts",
        "methods": [
          "GET"
        ],
        "handler": {
          "type": "controller",
          "method": "index",
          "moduleNameOrPath": "./app/features/auth/posts_controller.js"
        },
        "middleware": []
      },
      {
        "name": "posts.create",
        "pattern": "/posts/create",
        "methods": [
          "GET"
        ],
        "handler": {
          "type": "controller",
          "method": "create",
          "moduleNameOrPath": "./app/features/auth/posts_controller.js"
        },
        "middleware": []
      },
      {
        "name": "posts.store",
        "pattern": "/posts",
        "methods": [
          "POST"
        ],
        "handler": {
          "type": "controller",
          "method": "store",
          "moduleNameOrPath": "./app/features/auth/posts_controller.js"
        },
        "middleware": []
      },
      {
        "name": "posts.show",
        "pattern": "/posts/:id",
        "methods": [
          "GET"
        ],
        "handler": {
          "type": "controller",
          "method": "show",
          "moduleNameOrPath": "./app/features/auth/posts_controller.js"
        },
        "middleware": []
      },
      {
        "name": "posts.edit",
        "pattern": "/posts/:id/edit",
        "methods": [
          "GET"
        ],
        "handler": {
          "type": "controller",
          "method": "edit",
          "moduleNameOrPath": "./app/features/auth/posts_controller.js"
        },
        "middleware": []
      },
      {
        "name": "posts.update",
        "pattern": "/posts/:id",
        "methods": [
          "PUT",
          "PATCH"
        ],
        "handler": {
          "type": "controller",
          "method": "update",
          "moduleNameOrPath": "./app/features/auth/posts_controller.js"
        },
        "middleware": []
      },
      {
        "name": "posts.destroy",
        "pattern": "/posts/:id",
        "methods": [
          "DELETE"
        ],
        "handler": {
          "type": "controller",
          "method": "destroy",
          "moduleNameOrPath": "./app/features/auth/posts_controller.js"
        },
        "middleware": []
      },
      {
        "name": "users.index",
        "pattern": "/users",
        "methods": [
          "GET"
        ],
        "handler": {
          "type": "controller",
          "method": "index",
          "moduleNameOrPath": "./app/features/test_controller.js"
        },
        "middleware": []
      },
      {
        "name": "users.store",
        "pattern": "/users",
        "methods": [
          "POST"
        ],
        "handler": {
          "type": "controller",
          "method": "store",
          "moduleNameOrPath": "./app/features/test_controller.js"
        },
        "middleware": []
      }
    ]
  }
]
```

It won't work immediately, I'll need to push a commit just after that, to allow Tuyau to handle it. i will reference it here once it's done