### PR TITLE
fix(relative-path): Fixed windows to make tuyau:generate work

### DIFF
--- a/providers/girouette_provider.ts
+++ b/providers/girouette_provider.ts
@@ -240,7 +240,7 @@ export default class GirouetteProvider {
    * Creates a new route in the AdonisJS router
    */
   #createRoute(route: GirouetteRoute, controller: ControllerToProcess, methodName: string) {
-    const relativePath = relative(this.app.appRoot.pathname, controller.importUrl.pathname).replace(
+    const relativePath = relative(this.app.appRoot.pathname, controller.importUrl.pathname).replaceAll('\\', '/').replace(
       /\.ts$/,
       '.js'
     )
@@ -300,7 +300,7 @@ export default class GirouetteProvider {
       const relativePath = relative(
         this.app.appRoot.pathname,
         controller.importUrl.pathname
-      ).replace(/\.ts$/, '.js')
+      ).replaceAll('\\', '/').replace(/\.ts$/, '.js')
       const resource = this.#router!.resource(resourcePattern, `./${relativePath}`)
       this.#configureResource(resource, controller)
     } catch (error) {


### PR DESCRIPTION
This fix is ​​so that tuyau:generate on Windows can detect and work, because the Windows relative path function is different from Unix.